### PR TITLE
Added github repo to dist metadata

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -15,6 +15,11 @@ my $build = Module::Build->new(
         Test::Pod           => 0,
         Test::Pod::Coverage => 0,
     },
+    meta_merge => {
+        resources => {
+            repository => 'https://github.com/davorg/array-compare',
+        },
+    },
     create_makefile_pl => 'traditional',
 );
 


### PR DESCRIPTION
Hi Dave,

This adds the github repo to the dist's metadata. Then it will be a candidate for the PRC :-)

Would you be open to switching `Changes` to the basic format defined in `CPAN::Changes::Spec`? That way MetaCPAN will show the changes in the latest release when looking at the dist's page on MetaCPAN.

Cheers,
Neil
